### PR TITLE
Remove "/" from baseurl.

### DIFF
--- a/mozwebqa.cfg
+++ b/mozwebqa.cfg
@@ -1,3 +1,3 @@
 [DEFAULT]
 api = webdriver
-baseurl = https://reps-dev.allizom.org/
+baseurl = https://reps-dev.allizom.org


### PR DESCRIPTION
We pass the baseurl whit out the "/" in Jenkis.
Leaving it as it is, might confuse contributors and might cause fails when
creating tests that append something afther the baseurl.
