### PR TITLE
Add FAQ page link crawler test

### DIFF
--- a/tests/test_faq_page.py
+++ b/tests/test_faq_page.py
@@ -25,7 +25,7 @@ class TestFAQPage:
     @pytest.mark.nondestructive
     def test_that_links_in_the_faq_page_return_200_code(self, mozwebqa):
         crawler = LinkCrawler(mozwebqa)
-        urls = crawler.collect_links('/faq/', id='main')
+        urls = crawler.collect_links('/faq/', id='wrapper')
         bad_urls = []
 
         Assert.greater(


### PR DESCRIPTION
Issue #14 - verify the links on the faq page return HTTP 200 OK
