### PR TITLE
Add required arguments to requests.get() method

### DIFF
--- a/pages/link_crawler.py
+++ b/pages/link_crawler.py
@@ -46,7 +46,11 @@ class LinkCrawler(Page):
             lambda u: u if u.startswith('http') else '%s%s' % (self.base_url, u), urls)
 
     def verify_status_code_is_ok(self, url):
-        r = requests.get(url)
+        requests.adapters.DEFAULT_RETRIES = 5
+        try:
+            r = requests.get(url, verify=False, allow_redirects=True)
+        except requests.Timeout:
+            r.status_code = 408
         if not r.status_code == requests.codes.ok:
             return u'{0.url} returned: {0.status_code} {0.reason}'.format(r)
         else:


### PR DESCRIPTION
This fixes the failure seen at [1].

[1] http://qa-selenium.mv.mozilla.com:8080/job/remo.dev/158/
