### PR TITLE
issue50: linkcrawler test is for home, not about. function name change

### DIFF
--- a/tests/test_homepage.py
+++ b/tests/test_homepage.py
@@ -29,7 +29,7 @@ class TestHomePage(BaseTest):
 
     @pytest.mark.skip_selenium
     @pytest.mark.nondestructive
-    def test_that_links_in_the_about_page_return_200_code(self, mozwebqa):
+    def test_that_links_in_the_home_page_return_200_code(self, mozwebqa):
 
         crawler = LinkCrawler(mozwebqa)
         urls = crawler.collect_links('/', id='wrapper')


### PR DESCRIPTION
test name for linkcrawler on homepage incorrectly labelled it for about page

test_that_links_in_the_about_page_return_200_code

to

test_that_links_in_the_home_page_return_200_code
