### PR TITLE
Added an except for StaleElementReferenceException to is_element_visible logic

### DIFF
--- a/pages/page.py
+++ b/pages/page.py
@@ -8,6 +8,7 @@ import time
 from unittestzero import Assert
 from selenium.common.exceptions import NoSuchElementException
 from selenium.common.exceptions import ElementNotVisibleException
+from selenium.common.exceptions import StaleElementReferenceException
 from selenium.common.exceptions import TimeoutException
 from selenium.common.exceptions import WebDriverException
 from selenium.webdriver.common.by import By
@@ -35,7 +36,7 @@ class Page(object):
             WebDriverWait(self.selenium, 10).until(lambda s: self.selenium.title)
 
         Assert.equal(self.selenium.title, self._page_title,
-            "Expected page title: %s. Actual page title: %s" % (self._page_title, self.selenium.title))
+                     "Expected page title: %s. Actual page title: %s" % (self._page_title, self.selenium.title))
         return True
 
     def is_element_present(self, *locator):
@@ -52,7 +53,7 @@ class Page(object):
     def is_element_visible(self, *locator):
         try:
             return self._selenium_root.find_element(*locator).is_displayed()
-        except (NoSuchElementException, ElementNotVisibleException):
+        except (NoSuchElementException, ElementNotVisibleException, StaleElementReferenceException):
             return False
 
     def is_element_not_visible(self, *locator):


### PR DESCRIPTION
This is to address the intermittent failure as seen at http://qa-selenium.mv.mozilla.com:8080/job/remo.dev/476/testReport/junit/tests.test_people_page/TestPeoplePage/test_filter_results_by_name/

I believe that the element is changing in the middle of the call, which is resulting in the `StaleElementReferenceException`. Adding this to the `except` will allow Selenium to attempt to locate the element again.  

We did something similar to this in gaia-ui-tests recently.
