### PR TITLE
Update README #111

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ __note__
 To run tests which require user login:
 
 1. Obtain credentials for a test user from [personatestuser][testuser]
-2. Create a test user profile on the [mozillians-dev][remo] website
+2. Create a test user profile on the [mozillians-dev][mozillians] website
 3. Join #mozwebqa and ask for getting the testuser profile vouched
 4. Specify the path to credentials file like:
 


### PR DESCRIPTION
In reference to issue https://github.com/mozilla/remo-tests/issues/111  updated the readme file specifying the steps to run tests which require login 
