### PR TITLE
Unxfail test_events_icalendar_export because Bug 967392 was closed.

### DIFF
--- a/tests/test_events_page.py
+++ b/tests/test_events_page.py
@@ -78,9 +78,6 @@ class TestEventsPage:
         Assert.true(all_ok, '%s bad links found. ' % len(bad_urls) + ', '.join(bad_urls))
 
     @pytest.mark.nondestructive
-    @pytest.mark.xfail('"-dev.allizom" in config.getvalue("base_url")',
-                       reason='Bug 967392 - [dev] Discrepancies between the number of event displayed'
-                              ' on the site and the ones present in the ICAL export')
     def test_events_icalendar_export(self, mozwebqa):
         home_page = Home(mozwebqa)
 


### PR DESCRIPTION
The test has been xpassing on Jenkins for a while.
